### PR TITLE
Resolver declaration via schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ GoChinaDNS is a DNS proxy, which smartly dispatches DNS questions to get nearest
 
 ## Install
 
-This project is written in Go. To build it, you need [install Go](https://golang.org/doc/install) at first.
+Binaries for linux, windows and darwin (macOS) are available under Releases. 
 
-Build:
+You will also need a list of IP ranges in China, such as [@pexcn/chnroute.txt](https://raw.githubusercontent.com/pexcn/daily/gh-pages/chnroute/chnroute.txt).
+## Build
+This project is written in Go. If you want to build it yourself, you need to [install Go](https://golang.org/doc/install) first.
 
 ```shell
+git clone https://github.com/cherrot/gochinadns
+cd gochinadns
+go get -u ./...
 cd cmd/chinadns
 go build
 ```
 
+## Usage 
 Run:
 
 ```shell
@@ -25,11 +31,34 @@ Test:
 dig @::1 -p5553 google.com
 ```
 
+## Advanced usage 
+### Customize upstream servers
+```shell
+./chinadns -p 5553 -c ./china.list -s 114.114.114.114,127.0.0.1:5353
+```
+In this example, `127.0.0.1:5353` is the trusted resolver and can be a local dns forwarder (e.g. `dnscrypt-proxy`).
+
+**Note:** you still need to make sure that your trusted resolver is accessible through a secure channel otherwise your DNS will stilll get poisoned. 
+
+### Specify resolver protocol
+The default format for upstream resolvers is `ip:port` for backwards compatibility with ChinaDNS.
+Resolvers can also be passed as `protocol[+protocol]@ip:port` where protocol is `udp` or `tcp`.
+Protocols are dialed in the order they are written (left to right). 
+The rightmost protocol acts as a fallback and will only be dialed if the leftmost fails.
+
+For example, if the upstream resolver is a local dns forwarder on port 5353, it can be passed as `udp@127.0.0.1:5353`
+because fallback to TCP is not necessary. 
+
+Similarly, if you run a transparent TCP proxy that proxies traffic to 8.8.8.8 you could use `tcp@8.8.8.8`:
+
+```shell
+./chinadns -p 5553 -c ./china.list -s udp+tcp@114.114.114.114,udp@127.0.0.1:5353,tcp@8.8.8.8
+```
 ## Params
 ```
 $ ./chinadns -h
 
-Usage of ./chinadns:
+Usage of chinadns:
   -V    Print version and exit.
   -b string
         Bind address. (default "::")
@@ -50,16 +79,22 @@ Usage of ./chinadns:
   -reuse-port
         Enable SO_REUSEPORT to gain some performance optimization. Need Linux>=3.9 (default true)
   -s value
-        Upstream DNS servers. Need China route list to check whether it's a trusted server or not. (default 119.29.29.29,114.114.114.114)
+        Comma separated list of upstream DNS servers. Need China route list to check whether it's a trusted server or not.
+        Servers can be in format ip:port or protocol[+protocol]@ip:port where protocol is udp or tcp.
+        Protocols are used in the order they are defined (left to right).
+        If empty, protocol defaults to udp+tcp and port defaults to 53.
+        Examples: udp@8.8.8.8,udp+tcp@127.0.0.1:5353,1.1.1.1 (default udp+tcp@119.29.29.29,udp+tcp@114.114.114.114)
   -test-domains string
         Domain names to test DNS connection health. (default "qq.com,163.com")
   -timeout duration
         DNS request timeout (default 1s)
   -trusted-servers value
-        Servers which (located in China but) can be trusted. (default 193.112.15.186:2323)
+        Comma separated list of  servers which (located in China but) can be trusted.
+        Uses the same format as -s.
   -udp-max-bytes int
-        Default DNS max message size on UDP. (default 1410)
+        Default DNS max message size on UDP. (default 4096)
   -v    Enable verbose logging.
   -y float
         Delay (in seconds) to query another DNS server when no reply received. (default 0.1)
+
 ```

--- a/cmd/chinadns/main.go
+++ b/cmd/chinadns/main.go
@@ -36,13 +36,18 @@ var (
 	flagDomainBlacklist = flag.String("domain-blacklist", "", "Path to domain blacklist file.")
 	flagDomainPolluted  = flag.String("domain-polluted", "", "Path to polluted domains list. Queries of these domains will not be sent to DNS in China.")
 
-	flagResolvers        resolverAddrs = []string{"119.29.29.29:53", "114.114.114.114:53"}
+	flagResolvers        resolverAddrs = []string{"udp+tcp@119.29.29.29:53", "udp+tcp@114.114.114.114:53"}
 	flagTrustedResolvers resolverAddrs = []string{}
 )
 
 func init() {
-	flag.Var(&flagResolvers, "s", "Upstream DNS servers. Need China route list to check whether it's a trusted server or not.")
-	flag.Var(&flagTrustedResolvers, "trusted-servers", "Servers which (located in China but) can be trusted.")
+	flag.Var(&flagResolvers, "s", "Comma separated list of upstream DNS servers. Need China route list to check whether it's a trusted server or not.\n"+
+		"Servers can be in format ip:port or protocol[+protocol]@ip:port where protocol is udp or tcp.\n"+
+		"Protocols are used in the order they are defined (left to right).\n"+
+		"If empty, protocol defaults to udp+tcp and port defaults to 53.\n"+
+		"Examples: udp@8.8.8.8,udp+tcp@127.0.0.1:5353,1.1.1.1")
+	flag.Var(&flagTrustedResolvers, "trusted-servers", "Comma separated list of servers which (located in China but) can be trusted. \n"+
+		"Uses the same format as -s.")
 }
 
 type resolverAddrs []string

--- a/lookup.go
+++ b/lookup.go
@@ -11,11 +11,11 @@ import (
 )
 
 // LookupFunc looks up DNS request to the given server and returns DNS reply, its RTT time and an error.
-type LookupFunc func(request *dns.Msg, server string) (reply *dns.Msg, rtt time.Duration, err error)
+type LookupFunc func(request *dns.Msg, server resolver) (reply *dns.Msg, rtt time.Duration, err error)
 
 func lookupInServers(
 	ctx context.Context, cancel context.CancelFunc, result chan<- *dns.Msg, req *dns.Msg,
-	servers []string, waitInterval time.Duration, lookup LookupFunc,
+	servers []resolver, waitInterval time.Duration, lookup LookupFunc,
 ) {
 	defer cancel()
 	if len(servers) == 0 {
@@ -29,9 +29,9 @@ func lookupInServers(
 	queryNext <- struct{}{}
 	var wg sync.WaitGroup
 
-	doLookup := func(server string) {
+	doLookup := func(server resolver) {
 		defer wg.Done()
-		logger := logger.WithField("server", server)
+		logger := logger.WithField("server", server.getAddr())
 
 		reply, rtt, err := lookup(req.Copy(), server)
 		if err != nil {
@@ -68,14 +68,14 @@ LOOP:
 // DNS Proxy Implementation Guidelines: https://tools.ietf.org/html/rfc5625
 // DNS query processing: https://tools.ietf.org/html/rfc1034#section-3.7
 // Happy Eyeballs: https://tools.ietf.org/html/rfc6555#section-5.4 and #section-6
-func (s *Server) Lookup(req *dns.Msg, server string) (reply *dns.Msg, rtt time.Duration, err error) {
+func (s *Server) Lookup(req *dns.Msg, server resolver) (reply *dns.Msg, rtt time.Duration, err error) {
 	logger := logrus.WithFields(logrus.Fields{
 		"question": questionString(&req.Question[0]),
 		"server":   server,
 	})
 
 	if !s.TCPOnly {
-		reply, rtt, err = s.UDPCli.Exchange(req, server)
+		reply, rtt, err = s.UDPCli.Exchange(req, server.getAddr())
 		if err != nil {
 			logger.WithError(err).Error("Fail to send UDP query. Will retry in TCP.")
 		}
@@ -85,7 +85,7 @@ func (s *Server) Lookup(req *dns.Msg, server string) (reply *dns.Msg, rtt time.D
 	}
 	if reply == nil || reply.Truncated || err != nil {
 		rtt0 := rtt
-		reply, rtt, err = s.TCPCli.Exchange(req, server)
+		reply, rtt, err = s.TCPCli.Exchange(req, server.getAddr())
 		rtt += rtt0
 		if err != nil {
 			logger.WithError(err).Error("Fail to send TCP query.")
@@ -98,7 +98,7 @@ func (s *Server) Lookup(req *dns.Msg, server string) (reply *dns.Msg, rtt time.D
 // LookupMutation does the same as Lookup, with pointer mutation for DNS query.
 // DNS Compression: https://tools.ietf.org/html/rfc1035#section-4.1.4
 // DNS compression pointer mutation: https://gist.github.com/klzgrad/f124065c0616022b65e5#file-sendmsg-c-L30-L63
-func (s *Server) LookupMutation(req *dns.Msg, server string) (reply *dns.Msg, rtt time.Duration, err error) {
+func (s *Server) LookupMutation(req *dns.Msg, server resolver) (reply *dns.Msg, rtt time.Duration, err error) {
 	logger := logrus.WithFields(logrus.Fields{
 		"question": questionString(&req.Question[0]),
 		"server":   server,
@@ -136,8 +136,8 @@ func (s *Server) LookupMutation(req *dns.Msg, server string) (reply *dns.Msg, rt
 	return
 }
 
-func rawLookup(cli *dns.Client, id uint16, req []byte, server string, ddl time.Time, udpSize uint16) (*dns.Msg, error) {
-	conn, err := cli.Dial(server)
+func rawLookup(cli *dns.Client, id uint16, req []byte, server resolver, ddl time.Time, udpSize uint16) (*dns.Msg, error) {
+	conn, err := cli.Dial(server.getAddr())
 	if err != nil {
 		return nil, err
 	}

--- a/options.go
+++ b/options.go
@@ -5,49 +5,12 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/yl2chen/cidranger"
 )
-
-// resolver contains info about a single upstream DNS server.
-type resolver struct {
-	addr  string   //address of the resolver in format ip:port
-	proto []string //list of protocols to use with this resolver, in order of execution
-}
-
-func (r resolver) getAddr() string {
-	return r.addr
-}
-
-func (r resolver) getProto() []string {
-	return r.proto
-}
-
-// tcpOnly forces the resolver to only use tcp, regardless of the user input.
-// Required for backwards compatibility with v1.
-func (r resolver) tcpOnly() {
-	r.proto = []string{"tcp"}
-}
-
-func (r resolver) String() string {
-	return r.getAddr()
-}
-
-// resolverArray is just an array of type resolver.
-// It's not really required other than to define String() to print it nicely in the log.
-type resolverArray []resolver
-
-func (r resolverArray) String() string {
-	sb := new(strings.Builder)
-	for _, server := range r {
-		sb.WriteString(fmt.Sprintf("%s%s ", server.getProto(), server.getAddr()))
-	}
-	return sb.String()
-}
 
 // ServerOption provides ChinaDNS server options. Please use WithXXX functions to generate Options.
 type ServerOption func(*serverOptions) error
@@ -212,12 +175,9 @@ func WithDomainPolluted(path string) ServerOption {
 func WithTrustedResolvers(resolvers ...string) ServerOption {
 	return func(o *serverOptions) error {
 		for _, schema := range resolvers {
-			newResolver, err := schemaToResolver(schema)
+			newResolver, err := schemaToResolver(schema, o.TCPOnly)
 			if err != nil {
 				return errors.Wrap(err, "Schema error")
-			}
-			if o.TCPOnly {
-				newResolver.tcpOnly()
 			}
 			o.TrustedServers = uniqueAppendResolver(o.TrustedServers, newResolver)
 		}
@@ -231,15 +191,11 @@ func WithResolvers(resolvers ...string) ServerOption {
 			return errNotReady
 		}
 		for _, schema := range resolvers {
-			newResolver, err := schemaToResolver(schema)
+			newResolver, err := schemaToResolver(schema, o.TCPOnly)
 			if err != nil {
 				return errors.Wrap(err, "Schema error")
 			}
-			if o.TCPOnly {
-				newResolver.tcpOnly()
-			}
-
-			host, _, _ := net.SplitHostPort(newResolver.getAddr())
+			host, _, _ := net.SplitHostPort(newResolver.GetAddr())
 			contain, err := o.ChinaCIDR.Contains(net.ParseIP(host))
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("fail to check whether %s is in China", host))
@@ -265,7 +221,7 @@ func uniqueAppendString(to []string, item string) []string {
 
 func uniqueAppendResolver(to []resolver, item resolver) []resolver {
 	for _, e := range to {
-		if item.getAddr() == e.getAddr() {
+		if item.GetAddr() == e.GetAddr() {
 			return to
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -27,6 +27,12 @@ func (r resolver) getProto() []string {
 	return r.proto
 }
 
+// tcpOnly forces the resolver to only use tcp, regardless of the user input.
+// Required for backwards compatibility with v1.
+func (r resolver) tcpOnly() {
+	r.proto = []string{"tcp"}
+}
+
 func (r resolver) String() string {
 	return r.getAddr()
 }
@@ -210,6 +216,9 @@ func WithTrustedResolvers(resolvers ...string) ServerOption {
 			if err != nil {
 				return errors.Wrap(err, "Schema error")
 			}
+			if o.TCPOnly {
+				newResolver.tcpOnly()
+			}
 			o.TrustedServers = uniqueAppendResolver(o.TrustedServers, newResolver)
 		}
 		return nil
@@ -225,6 +234,9 @@ func WithResolvers(resolvers ...string) ServerOption {
 			newResolver, err := schemaToResolver(schema)
 			if err != nil {
 				return errors.Wrap(err, "Schema error")
+			}
+			if o.TCPOnly {
+				newResolver.tcpOnly()
 			}
 
 			host, _, _ := net.SplitHostPort(newResolver.getAddr())

--- a/schema.go
+++ b/schema.go
@@ -1,17 +1,60 @@
 package gochinadns
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 	"strings"
 )
 
+// resolver contains info about a single upstream DNS server.
+type resolver struct {
+	addr      string   //address of the resolver in format ip:port
+	protocols []string //list of protocols to use with this resolver, in order of execution
+}
+
+func (r resolver) GetAddr() string {
+	return r.addr
+}
+
+func (r resolver) GetProtocols() []string {
+	return r.protocols
+}
+
+func (r resolver) String() string {
+	return r.GetAddr()
+}
+
+// resolverArray is just an array of type resolver.
+// It's not really required other than to define String() to print it nicely in the log.
+type resolverArray []resolver
+
+func (r resolverArray) String() string {
+	sb := new(strings.Builder)
+	for _, server := range r {
+		sb.WriteString(fmt.Sprintf("%s%s ", server.GetProtocols(), server.GetAddr()))
+	}
+	return sb.String()
+}
+
 // schemaToResolver takes a single resolver in schema format and outputs a resolver struct.
 // Will also accept regular ip:port format for backwards compatibility.
 // The schema is defined as:  protocol[+protocol]@ip:port
-func schemaToResolver(input string) (r resolver, err error) {
+func schemaToResolver(input string, tcpOnly bool) (r resolver, err error) {
 	err = nil
 	fields := strings.Split(input, "@")
-	if len(fields) > 1 { //input is schema
+	if len(fields) == 1 { // input is ip:port
+		var proto []string
+		if tcpOnly {
+			proto = []string{"tcp"}
+		} else {
+			proto = []string{"udp", "tcp"}
+		}
+		r = resolver{
+			addr:      fields[0],
+			protocols: proto,
+		}
+		return
+	} else { //input is schema
 		//extract protocols
 		pr := strings.Split(strings.ToLower(fields[0]), "+")
 		var proto []string
@@ -19,24 +62,14 @@ func schemaToResolver(input string) (r resolver, err error) {
 		for _, protocol := range pr {
 			er := checkProtocol(protocol)
 			if er != nil {
-				r = resolver{
-					addr:  "",
-					proto: []string{},
-				}
 				err = errors.Wrapf(er, "Error in resolver [%s]", input)
 				return
 			}
 			proto = uniqueAppendString(proto, protocol)
 		}
 		r = resolver{
-			addr:  fields[1],
-			proto: proto,
-		}
-		return
-	} else { // input is ip:port
-		r = resolver{
-			addr:  fields[0],
-			proto: []string{"udp", "tcp"},
+			addr:      fields[1],
+			protocols: proto,
 		}
 		return
 	}

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,52 @@
+package gochinadns
+
+import (
+	"github.com/pkg/errors"
+	"strings"
+)
+
+// schemaToResolver takes a single resolver in schema format and outputs a resolver struct.
+// Will also accept regular ip:port format for backwards compatibility.
+// The schema is defined as:  protocol[+protocol]@ip:port
+func schemaToResolver(input string) (r resolver, err error) {
+	err = nil
+	fields := strings.Split(input, "@")
+	if len(fields) > 1 { //input is schema
+		//extract protocols
+		pr := strings.Split(strings.ToLower(fields[0]), "+")
+		var proto []string
+		// check if the protocols are valid
+		for _, protocol := range pr {
+			er := checkProtocol(protocol)
+			if er != nil {
+				r = resolver{
+					addr:  "",
+					proto: []string{},
+				}
+				err = errors.Wrapf(er, "Error in resolver [%s]", input)
+				return
+			}
+			proto = uniqueAppendString(proto, protocol)
+		}
+		r = resolver{
+			addr:  fields[1],
+			proto: proto,
+		}
+		return
+	} else { // input is ip:port
+		r = resolver{
+			addr:  fields[0],
+			proto: []string{"udp", "tcp"},
+		}
+		return
+	}
+}
+
+// checkProtocol checks if a valid protocol is specified.
+func checkProtocol(p string) error {
+	if p == "udp" || p == "tcp" {
+		return nil
+	} else {
+		return errors.Errorf("Unknown protocol [%s]", p)
+	}
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -13,41 +13,32 @@ func Test_schemaToResolver(t *testing.T) {
 		wantErr bool
 	}{
 		{"8.8.8.8:53", resolver{
-			addr:  "8.8.8.8:53",
-			proto: []string{"udp", "tcp"},
+			addr:      "8.8.8.8:53",
+			protocols: []string{"udp", "tcp"},
 		}, false},
 		{"udp@8.8.8.8:54", resolver{
-			addr:  "8.8.8.8:54",
-			proto: []string{"udp"},
+			addr:      "8.8.8.8:54",
+			protocols: []string{"udp"},
 		}, false},
 		{"UDP+tcp@8.8.8.8:53", resolver{
-			addr:  "8.8.8.8:53",
-			proto: []string{"udp", "tcp"},
+			addr:      "8.8.8.8:53",
+			protocols: []string{"udp", "tcp"},
 		}, false},
 		{"UDP+udp+tcp@8.8.8.8:53", resolver{
-			addr:  "8.8.8.8:53",
-			proto: []string{"udp", "tcp"},
+			addr:      "8.8.8.8:53",
+			protocols: []string{"udp", "tcp"},
 		}, false},
 		{"tcp+udp@8.8.8.8:53", resolver{
-			addr:  "8.8.8.8:53",
-			proto: []string{"tcp", "udp"},
+			addr:      "8.8.8.8:53",
+			protocols: []string{"tcp", "udp"},
 		}, false},
-		{"@8.8.8.8:53", resolver{
-			addr:  "",
-			proto: []string{},
-		}, true},
-		{"asdf@8.8.8.8:53", resolver{
-			addr:  "",
-			proto: []string{},
-		}, true},
-		{"wut+tcp@8.8.8.8:53", resolver{
-			addr:  "",
-			proto: []string{},
-		}, true},
+		{"@8.8.8.8:53", resolver{}, true},
+		{"asdf@8.8.8.8:53", resolver{}, true},
+		{"wut+tcp@8.8.8.8:53", resolver{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			gotR, err := schemaToResolver(tt.input)
+			gotR, err := schemaToResolver(tt.input, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("schemaToResolver() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,60 @@
+package gochinadns
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_schemaToResolver(t *testing.T) {
+
+	tests := []struct {
+		input   string
+		wantR   resolver
+		wantErr bool
+	}{
+		{"8.8.8.8:53", resolver{
+			addr:  "8.8.8.8:53",
+			proto: []string{"udp", "tcp"},
+		}, false},
+		{"udp@8.8.8.8:54", resolver{
+			addr:  "8.8.8.8:54",
+			proto: []string{"udp"},
+		}, false},
+		{"UDP+tcp@8.8.8.8:53", resolver{
+			addr:  "8.8.8.8:53",
+			proto: []string{"udp", "tcp"},
+		}, false},
+		{"UDP+udp+tcp@8.8.8.8:53", resolver{
+			addr:  "8.8.8.8:53",
+			proto: []string{"udp", "tcp"},
+		}, false},
+		{"tcp+udp@8.8.8.8:53", resolver{
+			addr:  "8.8.8.8:53",
+			proto: []string{"tcp", "udp"},
+		}, false},
+		{"@8.8.8.8:53", resolver{
+			addr:  "",
+			proto: []string{},
+		}, true},
+		{"asdf@8.8.8.8:53", resolver{
+			addr:  "",
+			proto: []string{},
+		}, true},
+		{"wut+tcp@8.8.8.8:53", resolver{
+			addr:  "",
+			proto: []string{},
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotR, err := schemaToResolver(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("schemaToResolver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotR, tt.wantR) {
+				t.Errorf("schemaToResolver() gotR = %v, want %v", gotR, tt.wantR)
+			}
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -71,7 +71,7 @@ const _loop = 2
 
 func (s *Server) refineResolvers() {
 	type test struct {
-		addr   string
+		server resolver
 		errCnt int
 		rttAvg time.Duration
 	}
@@ -82,7 +82,7 @@ func (s *Server) refineResolvers() {
 	req := new(dns.Msg)
 
 	for i, resolver := range s.TrustedServers {
-		trusted[i].addr = resolver
+		trusted[i].server = resolver
 		for j := 0; j < _loop; j++ {
 			for _, name := range s.TestDomains {
 				req.SetQuestion(dns.Fqdn(name), dns.TypeA)
@@ -119,7 +119,7 @@ func (s *Server) refineResolvers() {
 	})
 
 	for i, resolver := range s.UntrustedServers {
-		untrusted[i].addr = resolver
+		untrusted[i].server = resolver
 		for j := 0; j < _loop; j++ {
 			for _, name := range s.TestDomains {
 				req.SetQuestion(dns.Fqdn(name), dns.TypeA)
@@ -147,13 +147,13 @@ func (s *Server) refineResolvers() {
 		return untrusted[i].errCnt < untrusted[j].errCnt
 	})
 
-	s.TrustedServers = make([]string, len(trusted))
-	s.UntrustedServers = make([]string, len(untrusted))
+	s.TrustedServers = make([]resolver, len(trusted))
+	s.UntrustedServers = make([]resolver, len(untrusted))
 	for i, t := range trusted {
-		s.TrustedServers[i] = t.addr
+		s.TrustedServers[i] = t.server
 	}
 	for i, t := range untrusted {
-		s.UntrustedServers[i] = t.addr
+		s.UntrustedServers[i] = t.server
 	}
 
 	if tLen == 0 {


### PR DESCRIPTION
Closes #8 .

You can now declare resolvers in the format `udp+tcp@ip:port` (second protocol is optional). Resolvers are then queried with the defined protocol(s), from left to right. This allows you to disable fallback and only try one protocol if you want. Before we had TCPOnly flag, but no UDPOnly. Now you can do both and configure protocols for each server individually.

Old format of ip:port is also kept for backwards compatibility (you can mix and match, e.g. ` tcp@8.8.8.8,114.114.114.114,udp+tcp@127.0.0.1:5353` is all valid. ) If protocol is not defined, defaults to udp+tcp.

See updated README and -h output for examples.

This makes -TCPOnly flag redundant, because you can specify the resolver as `tcp@ip:port` to do the same thing. But I think it's better to keep it in for backwards compatibility. If TCPOnly is set, all resolvers are forced to tcp.
